### PR TITLE
Support file paths with spaces

### DIFF
--- a/src/main/java/org/zapodot/junit/ldap/internal/EmbeddedLdapRuleImpl.java
+++ b/src/main/java/org/zapodot/junit/ldap/internal/EmbeddedLdapRuleImpl.java
@@ -23,6 +23,7 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.ldap.LdapContext;
 import java.util.Hashtable;
 import java.util.List;
+import java.net.URLDecoder;
 
 public class EmbeddedLdapRuleImpl implements EmbeddedLdapRule {
 
@@ -56,7 +57,7 @@ public class EmbeddedLdapRuleImpl implements EmbeddedLdapRule {
                 new InMemoryDirectoryServer(inMemoryDirectoryServerConfig);
         if (ldifs != null && !ldifs.isEmpty()) {
             for (final String ldif : ldifs) {
-                ldapServer.importFromLDIF(false, Resources.getResource(ldif).getPath());
+                ldapServer.importFromLDIF(false, URLDecoder.decode(Resources.getResource(ldif).getPath(), "UTF-8"));
             }
         }
         return ldapServer;


### PR DESCRIPTION
The current getPath() method returns an URL where spaces are converted to "%20". This in turn makes it hard for the LDIFReader that eventually gets the string to read it since it uses a FileInputStream.