### PR TITLE
Support file paths with spaces

### DIFF
--- a/src/main/java/org/zapodot/junit/ldap/internal/EmbeddedLdapRuleImpl.java
+++ b/src/main/java/org/zapodot/junit/ldap/internal/EmbeddedLdapRuleImpl.java
@@ -8,6 +8,7 @@ import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.LDAPInterface;
+
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
@@ -21,6 +22,9 @@ import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.ldap.LdapContext;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -56,7 +60,11 @@ public class EmbeddedLdapRuleImpl implements EmbeddedLdapRule {
                 new InMemoryDirectoryServer(inMemoryDirectoryServerConfig);
         if (ldifs != null && !ldifs.isEmpty()) {
             for (final String ldif : ldifs) {
-                ldapServer.importFromLDIF(false, Resources.getResource(ldif).getPath());
+                try {
+                  ldapServer.importFromLDIF(false, URLDecoder.decode(Resources.getResource(ldif).getPath(), "UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                  throw new IllegalStateException("Can not URL decode path:" + Resources.getResource(ldif).getPath(), e);
+                }
             }
         }
         return ldapServer;


### PR DESCRIPTION
The current getPath() method returns an URL where spaces are converted to "%20". This in turn makes it hard for the LDIFReader that eventually gets the string to read it since it uses a FileInputStream.

The pull request has improved - now with exception handling :)