### PR TITLE
 Allow running the LDAP server with no schema at all 

### DIFF
--- a/src/main/java/org/zapodot/junit/ldap/EmbeddedLdapRuleBuilder.java
+++ b/src/main/java/org/zapodot/junit/ldap/EmbeddedLdapRuleBuilder.java
@@ -192,9 +192,7 @@ public class EmbeddedLdapRuleBuilder {
                     bindPort,
                     null);
             inMemoryDirectoryServerConfig.setListenerConfigs(listenerConfig);
-            for (Schema s : customSchema().asSet()) {
-                inMemoryDirectoryServerConfig.setSchema(s);
-            }
+            inMemoryDirectoryServerConfig.setSchema(customSchema());
             return inMemoryDirectoryServerConfig;
         } catch (LDAPException e) {
             throw new IllegalStateException(
@@ -211,7 +209,7 @@ public class EmbeddedLdapRuleBuilder {
         }
     }
 
-    private Optional<Schema> customSchema() {
+    private Schema customSchema() {
         final List<File> schemaFiles = schemaFiles();
 
         try {
@@ -220,9 +218,9 @@ public class EmbeddedLdapRuleBuilder {
                 final Schema customSchema = initialSchema == null
                                             ? Schema.getSchema(schemaFiles)
                                             : Schema.mergeSchemas(initialSchema, Schema.getSchema(schemaFiles));
-                return Optional.fromNullable(customSchema);
+                return customSchema;
             } else {
-                return Optional.absent();
+                return null;
             }
 
         } catch (IOException | LDIFException | LDAPException e) {

--- a/src/test/java/org/zapodot/junit/ldap/EmbeddedLdapRuleCustomWithoutSchemaTest.java
+++ b/src/test/java/org/zapodot/junit/ldap/EmbeddedLdapRuleCustomWithoutSchemaTest.java
@@ -1,0 +1,23 @@
+package org.zapodot.junit.ldap;
+
+import com.unboundid.ldap.sdk.schema.Schema;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class EmbeddedLdapRuleCustomWithoutSchemaTest {
+
+    @Rule
+    public EmbeddedLdapRule embeddedLdapRule = EmbeddedLdapRuleBuilder.newInstance()
+                                                                      .withoutDefaultSchema()
+                                                                      .build();
+
+    @Test
+    public void testEmptySchema() throws Exception {
+        final Schema schema =
+                embeddedLdapRule.ldapConnection().getSchema();
+        assertTrue(schema.getAttributeTypes().isEmpty());
+
+    }
+}


### PR DESCRIPTION
Unbound allows the schema of the server to be set null. This prevents all schema validation.

This change allows to run the LDAP server in this mode.

You have now the following possibilities for running the server:

#### 1. Run the server with the default schema
```java
EmbeddedLdapRuleBuilder
.newInstance()
.build();
```

#### 2. Run the server without a schema
```java
EmbeddedLdapRuleBuilder
.newInstance()
.withoutDefaultSchema()
.build();
```

#### 3. Run the server with the default schema and the custom schema
```java
EmbeddedLdapRuleBuilder
.newInstance()
.withSchema("custom.ldif")
.build();
```

#### 4. Run the server with only the custom schema
```java
EmbeddedLdapRuleBuilder
.newInstance()
.withoutDefaultSchema()
.withSchema("custom.ldif")
.build();
```

Previously option 2. was not available, in fact the code from option 2. would do the same as option 1.

I have split the pull request in two commits. The first one contains the test case, that demonstrates the wrong behavior for option 2. The second commit fixes it.
